### PR TITLE
Fix Mongoose not AutoPushing db updates

### DIFF
--- a/offix-web/models/user.js
+++ b/offix-web/models/user.js
@@ -14,6 +14,9 @@ userSchema = new mongoose.Schema({
   shouldBroadcast: {type: Boolean, default: true},
   // we're not currently collecting historical data, and we're not associating
   // last seen times with specific MAC addresses
+},
+{
+  usePushEach: true,
 });
 
 userSchema.statics.register = function(username, password, realName, callback) {


### PR DESCRIPTION
The `pushAll` got deprecated and then removed in later MongoDB versions, so Mongoose has an option to workaround that.

Using this for UTK IEEE Robotics team - love the app!